### PR TITLE
detach http/https modules from FeatureService instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Moved to koopjs github organization
 
+### Fixed
+* detach http/https modules from FeatureService instances
+
 ## [0.2.0] - 2015-08-06
 ### Added
 * Feature requests time out

--- a/index.js
+++ b/index.js
@@ -36,12 +36,6 @@ var FeatureService = function (url, options) {
   this.pageQueue = queue(function (task, callback) {
     this._requestFeatures(task, callback)
   }.bind(this), (this.url.split('//')[1].match(/^service/)) ? 16 : 4)
-
-  // easy reference to a protocol type
-  this.protocols = {
-    http: http,
-    https: https
-  }
 }
 
 /**
@@ -65,8 +59,9 @@ FeatureService.prototype.request = function (url, callback) {
   }
 
   // make an http or https request based on the protocol
-  var req = ((uri.protocol === 'https:') ? this.protocols.https : this.protocols.http).request(opts, function (response) {
+  var req = ((uri.protocol === 'https:') ? https : http).request(opts, function (response) {
     var data = []
+
     response.on('data', function (chunk) {
       data.push(chunk)
     })
@@ -398,7 +393,7 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
     }
 
     // make an http or https request based on the protocol
-    var req = ((url_parts.protocol === 'https:') ? this.protocols.https : this.protocols.http).request(opts, function (response) {
+    var req = ((url_parts.protocol === 'https:') ? https : http).request(opts, function (response) {
       var data = []
       response.on('data', function (chunk) {
         data.push(chunk)


### PR DESCRIPTION
We definitely shouldn't be attaching the entirety of both the `http` and `https` modules to every FeatureService instance.