### PR TITLE
standardize errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Pages based on object ids are now formed correctly
 
+### Changed
+* All errors returned to the requestor are standardized
+
 ## [1.1.1] - 2015-08-10
 ### Fixed
 * Build dist for changes

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ FeatureService.prototype.layerInfo = function (callback) {
     if (err || !json || (json && json.error)) {
       var error = new Error('Request for layer information failed')
       error.url = url
-      error.ref = err || json
+      error.body = err || json
 
       return callback(error)
     }
@@ -173,7 +173,7 @@ FeatureService.prototype.layerIds = function (callback) {
     if (err || !json.objectIds) {
       var error = new Error('Request for object IDs failed')
       error.url = url
-      error.ref = json
+      error.body = json
 
       return callback(error)
     }
@@ -285,7 +285,7 @@ FeatureService.prototype.featureCount = function (callback) {
     if (err || json.error) {
       var error = new Error('Request for feature count failed')
       error.url = countUrl
-      error.ref = json
+      error.body = json
 
       return callback(error)
     }
@@ -485,7 +485,7 @@ FeatureService.prototype._catchErrors = function (task, err, url, cb) {
   var error = new Error('Request for a page of features failed')
   error.code = err.code
   error.url = url
-  error.ref = err
+  error.body = err
 
   if (task.retry && task.retry === 3) return this._abortPaging(error, cb)
 

--- a/index.js
+++ b/index.js
@@ -483,6 +483,7 @@ FeatureService.prototype._decode = function (res, data, callback) {
  */
 FeatureService.prototype._catchErrors = function (task, err, url, cb) {
   var error = new Error('Request for a page of features failed')
+  error.code = err.code
   error.url = url
   error.ref = err
 

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ FeatureService.prototype.layerInfo = function (callback) {
     }
     json.url = url
     callback(null, json)
-  }.bind(this))
+  })
 }
 
 /**
@@ -180,7 +180,7 @@ FeatureService.prototype.layerIds = function (callback) {
     // TODO: is this really necessary
     json.objectIds.sort(function (a, b) { return a - b })
     callback(null, json.objectIds)
-  }.bind(this))
+  })
 }
 
 /**
@@ -291,7 +291,7 @@ FeatureService.prototype.featureCount = function (callback) {
     }
 
     callback(null, json)
-  }.bind(this))
+  })
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -175,23 +175,20 @@ test('should callback with an error when decoding json with an error in the resp
 
 test('catching errors with a json payload', function (t) {
   var service = new FeatureService('http://service.com/mapserver/2')
-  var task = {retry: 3}
-  var error = {
-    code: 400,
-    message: 'Invalid or missing input parameters.',
-    details: []
-  }
-  var url = 'http://url.com'
+  var task = { retry: 3 }
+  var error = new Error('Invalid or missing input parameters.')
+  error.code = 400
+  error.url = 'http://url.com'
 
   sinon.stub(service, '_abortPaging', function (error, cb) {
     cb(error)
   })
 
-  service._catchErrors(task, error, url, function (info) {
+  service._catchErrors(task, error, error.url, function (info) {
     t.equal(info.message, 'Request for a page of features failed')
     t.equal(info.code, error.code)
-    t.equal(info.request, url)
-    t.equal(info.response, error.message)
+    t.equal(info.url, error.url)
+    t.equal(info.ref.message, error.message)
     service._abortPaging.restore()
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,7 @@ test('catching errors with a json payload', function (t) {
     t.equal(info.message, 'Request for a page of features failed')
     t.equal(info.code, error.code)
     t.equal(info.url, error.url)
-    t.equal(info.ref.message, error.message)
+    t.equal(info.body.message, error.message)
     service._abortPaging.restore()
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -183,18 +183,12 @@ test('catching errors with a json payload', function (t) {
   }
   var url = 'http://url.com'
 
-  sinon.stub(service, '_abortPaging', function (msg, url, eMsg, eCode, cb) {
-    var info = {
-      message: msg,
-      request: url,
-      response: eMsg,
-      code: eCode
-    }
-    cb(info)
+  sinon.stub(service, '_abortPaging', function (error, cb) {
+    cb(error)
   })
 
   service._catchErrors(task, error, url, function (info) {
-    t.equal(info.message, 'Failed to request a page of features')
+    t.equal(info.message, 'Request for a page of features failed')
     t.equal(info.code, error.code)
     t.equal(info.request, url)
     t.equal(info.response, error.message)


### PR DESCRIPTION
Every error returned back to the requestor will now have the same format

``` json
{
    "message": "a human readable message",
    "type": "a general type of the failure",
    "code": "the response code from the server",
    "request": "the uri that was requested",
    "response": "error message from the server"
}
```
