### PR TITLE
standarize errors on metadata requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 * Errors after timeouts conform to standard
+* Errors on metadata requests conform to standard
 
 ### Fixed
 * Requests are ended correctly after timeouts

--- a/index.js
+++ b/index.js
@@ -133,8 +133,9 @@ FeatureService.prototype.layerInfo = function (callback) {
   this.request(url, function (err, json) {
     if (err || !json || (json && json.error)) {
       var error = new Error('Request for layer information failed')
+      error.code = json.error.code || 500
       error.url = url
-      error.body = err || json
+      error.body = err || json.error
 
       return callback(error)
     }
@@ -167,8 +168,9 @@ FeatureService.prototype.layerIds = function (callback) {
   this.request(url, function (err, json) {
     if (err || !json.objectIds) {
       var error = new Error('Request for object IDs failed')
+      error.code = json.error.code || 500
       error.url = url
-      error.body = json
+      error.body = err || json.error
 
       return callback(error)
     }
@@ -276,11 +278,11 @@ FeatureService.prototype.featureCount = function (callback) {
   countUrl += '/query?where=1=1&returnCountOnly=true&f=json'
 
   this.request(countUrl, function (err, json) {
-    // TODO what's in this error object and how can I use it?
     if (err || json.error) {
       var error = new Error('Request for feature count failed')
+      error.code = json.error.code || 500
       error.url = countUrl
-      error.body = json
+      error.body = err || json.error
 
       return callback(error)
     }

--- a/index.js
+++ b/index.js
@@ -121,7 +121,18 @@ FeatureService.prototype._statsUrl = function (field, stats) {
  * @param {array} stats - an array of stats to request: ['min', 'max', 'avg', 'stddev', 'count']
  */
 FeatureService.prototype.statistics = function (field, stats, callback) {
-  this.request(this._statsUrl(field, stats), callback)
+  var url = this._statsUrl(field, stats)
+  this.request(url, function (err, json) {
+    if (err || json.error) {
+      var error = new Error('Request for statistics failed')
+      error.timestamp = new Date()
+      error.code = json.error.code || 500
+      error.body = err || json.error
+      error.url = url
+      return callback(error)
+    }
+    callback(null, json)
+  })
 }
 
 /**
@@ -133,6 +144,7 @@ FeatureService.prototype.layerInfo = function (callback) {
   this.request(url, function (err, json) {
     if (err || !json || (json && json.error)) {
       var error = new Error('Request for layer information failed')
+      error.timeStamp = new Date()
       error.code = json.error.code || 500
       error.url = url
       error.body = err || json.error
@@ -168,6 +180,7 @@ FeatureService.prototype.layerIds = function (callback) {
   this.request(url, function (err, json) {
     if (err || !json.objectIds) {
       var error = new Error('Request for object IDs failed')
+      error.timeStamp = new Date()
       error.code = json.error.code || 500
       error.url = url
       error.body = err || json.error
@@ -258,8 +271,9 @@ FeatureService.prototype.pages = function (callback) {
  */
 FeatureService.prototype._getIdRangeFromStats = function (meta, callback) {
 
-  this.statistics(meta.oid, ['min', 'max'], function (reqErr, stats) {
-    if (reqErr || stats.error) return callback(new Error('statistics request failed'))
+  this.statistics(meta.oid, ['min', 'max'], function (err, stats) {
+    // TODO this is handled elsewhere now so move it
+    if (err) return callback(err)
     var attrs = stats.features[0].attributes
     // dmf: what's up with this third strategy?
     var names = stats && stats.fieldAliases ? Object.keys(stats.fieldAliases) : null
@@ -280,6 +294,7 @@ FeatureService.prototype.featureCount = function (callback) {
   this.request(countUrl, function (err, json) {
     if (err || json.error) {
       var error = new Error('Request for feature count failed')
+      error.timeStamp = new Date()
       error.code = json.error.code || 500
       error.url = countUrl
       error.body = err || json.error
@@ -420,6 +435,7 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
           // server responds 200 with error in the payload so we have to inspect
           if (json.error) {
             this.error = new Error('Request for a page of features failed')
+            this.error.timeStamp = new Date()
             this.error.body = json.error
             return self._catchErrors(task, this.error, uri, cb)
           }
@@ -431,6 +447,7 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
     req.setTimeout(self.timeOut, function () {
       // kill it immediately if a timeout occurs
       this.error = new Error('The request timed out after ' + self.timeOut / 1000 + ' seconds.')
+      this.error.timestamp = new Date()
       this.error.code = 504
       req.abort()
     })
@@ -439,6 +456,7 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
     req.on('error', function (err) {
       // if an error came in from setTimeOut, use that, else use the default error
       var reported = this.error ? this.error : err
+      reported.timestamp = reported.timestamp || new Date()
       self._catchErrors(task, reported, uri, cb)
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ var layerInfo = JSON.parse(fs.readFileSync('./test/fixtures/layerInfo.json'))
 var layerFixture = JSON.parse(fs.readFileSync('./test/fixtures/layer.json'))
 var idFixture = JSON.parse(fs.readFileSync('./test/fixtures/objectIds.json'))
 var countFixture = JSON.parse(fs.readFileSync('./test/fixtures/count.json'))
+var securedFixture = JSON.parse(fs.readFileSync('./test/fixtures/secured.json'))
 
 test('get the objectId', function (t) {
   var oid = service.getObjectIdField(layerInfo)
@@ -79,7 +80,7 @@ test('get all the object ids for a layer on the service', function (t) {
   })
 })
 
-test('get all feature count for a layer on the service', function (t) {
+test('get the feature count for a layer on the service', function (t) {
   sinon.stub(service, 'request', function (url, callback) {
     callback(null, countFixture)
   })
@@ -87,6 +88,45 @@ test('get all feature count for a layer on the service', function (t) {
     t.equal(err, null)
     var expected = 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=1=1&returnCountOnly=true&f=json'
     t.equal(service.request.calledWith(expected), true)
+    service.request.restore()
+    t.end()
+  })
+})
+
+test('get a json error when trying to get a feature count', function (t) {
+  sinon.stub(service, 'request', function (url, callback) {
+    callback(null, securedFixture)
+  })
+  service.featureCount(function (err, count) {
+    t.notEqual(typeof err, 'undefined')
+    t.equal(err.code, 499)
+    t.equal(err.body.message, 'Token Required')
+    service.request.restore()
+    t.end()
+  })
+})
+
+test('get a json error when trying to get layer ids', function (t) {
+  sinon.stub(service, 'request', function (url, callback) {
+    callback(null, securedFixture)
+  })
+  service.layerIds(function (err, count) {
+    t.notEqual(typeof err, 'undefined')
+    t.equal(err.code, 499)
+    t.equal(err.body.message, 'Token Required')
+    service.request.restore()
+    t.end()
+  })
+})
+
+test('get a json error when trying to get layer info', function (t) {
+  sinon.stub(service, 'request', function (url, callback) {
+    callback(null, securedFixture)
+  })
+  service.layerInfo(function (err, count) {
+    t.notEqual(typeof err, 'undefined')
+    t.equal(err.code, 499)
+    t.equal(err.body.message, 'Token Required')
     service.request.restore()
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -132,6 +132,19 @@ test('get a json error when trying to get layer info', function (t) {
   })
 })
 
+test('get a json error when trying to get statistics', function (t) {
+  sinon.stub(service, 'request', function (url, callback) {
+    callback(null, securedFixture)
+  })
+  service.statistics('foo', ['max'], function (err, count) {
+    t.notEqual(typeof err, 'undefined')
+    t.equal(err.code, 499)
+    t.equal(err.body.message, 'Token Required')
+    service.request.restore()
+    t.end()
+  })
+})
+
 test('time out when there is no response', function (t) {
   var error
   service.timeOut = 5


### PR DESCRIPTION
Ok this is the end of standardizing errors. I'd really like to move all requests and error handling into a single logic flow but that is out of scope for the moment.

This PR just makes sure that `layerInfo`, `layerIds`, `statistics` and `featureCount` return errors in the same way that paging requests do.

It also adds timestamps to all the error objects so we can pass that along to koop-agol

ping @ngoldman 
