### PR TITLE
fix range pages when layer id > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Restrict max record count to 5000 or less
+
+### Fixed
+* Pages generated from statistics use the correct layer when index > 0
+
 ## [1.2.3]
 ### Fixed
 * Do not exclude object ids === 0 when building pages

--- a/index.js
+++ b/index.js
@@ -312,16 +312,17 @@ FeatureService.prototype.featureCount = function (callback) {
  * @param {number} pages - the number of pages we'll create
  * @param {number} max - the max number of feature per page
  */
-FeatureService.prototype._offsetPages = function (pages, max) {
+FeatureService.prototype._offsetPages = function (pages, size) {
   var reqs = []
   var resultOffset
   var url = this.url
+  size = size > 5000 ? 5000 : size
 
   for (var i = 0; i < pages; i++) {
-    resultOffset = i * max
+    resultOffset = i * size
     var pageUrl = url + '/' + (this.layer) + '/query?outSR=4326&f=json&outFields=*&where=1=1'
     pageUrl += '&resultOffset=' + resultOffset
-    pageUrl += '&resultRecordCount=' + max
+    pageUrl += '&resultRecordCount=' + size
     pageUrl += '&geometry=&returnGeometry=true&geometryPrecision='
     reqs.push({req: pageUrl})
   }
@@ -339,6 +340,7 @@ FeatureService.prototype._idPages = function (ids, size) {
   var reqs = []
   var oidField = this.options.objectIdField || 'objectId'
   var pages = (ids.length / size)
+  size = size > 5000 ? 5000 : size
 
   for (var i = 0; i < pages + 1; i++) {
     var pageIds = ids.splice(0, size)
@@ -370,6 +372,7 @@ FeatureService.prototype._rangePages = function (stats, size) {
   var pageMin
   var where
   var objId = this.options.objectIdField
+  size = size > 5000 ? 5000 : size
 
   var url = this.url
   var pages = Math.max((stats.max === size) ? stats.max : Math.ceil((stats.max - stats.min) / size), 1)
@@ -383,8 +386,8 @@ FeatureService.prototype._rangePages = function (stats, size) {
       pageMax = stats.min + (size * (i + 1)) - 1
     }
     pageMin = stats.min + (size * i)
-    where = objId + '<=' + pageMax + '+AND+' + objId + '>=' + pageMin
-    pageUrl = url + '/' + (this.options.layer || 0) + '/query?outSR=4326&where=' + where + '&f=json&outFields=*'
+    where = [objId, '>=', pageMin, '+AND+', objId, '<=', pageMax].join('')
+    pageUrl = url + '/' + (this.layer || 0) + '/query?outSR=4326&where=' + where + '&f=json&outFields=*'
     pageUrl += '&geometry=&returnGeometry=true&geometryPrecision='
     reqs.push({req: pageUrl})
   }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var FeatureService = function (url, options) {
 
   this.url = url
   this.options = options || {}
+  this.options.size = this.options.size || 5000
   this.layer = layer || this.options.layer || 0
   this.timeOut = 1.5 * 60 * 1000
   var concurrency = this.url.split('//')[1].match(/^service/) ? 16 : 4
@@ -233,6 +234,9 @@ FeatureService.prototype.pages = function (callback) {
     if (err) return callback(err)
 
     var size = Math.min(parseInt(meta.size, 10), 1000) || 1000
+    // restrict page size to the passed in maximum
+    if (size > 5000) size = this.options.maxPageSize
+
     var layer = meta.layer
     var nPages = Math.ceil(meta.count / size)
 
@@ -316,7 +320,6 @@ FeatureService.prototype._offsetPages = function (pages, size) {
   var reqs = []
   var resultOffset
   var url = this.url
-  size = size > 5000 ? 5000 : size
 
   for (var i = 0; i < pages; i++) {
     resultOffset = i * size
@@ -340,7 +343,6 @@ FeatureService.prototype._idPages = function (ids, size) {
   var reqs = []
   var oidField = this.options.objectIdField || 'objectId'
   var pages = (ids.length / size)
-  size = size > 5000 ? 5000 : size
 
   for (var i = 0; i < pages + 1; i++) {
     var pageIds = ids.splice(0, size)
@@ -372,7 +374,6 @@ FeatureService.prototype._rangePages = function (stats, size) {
   var pageMin
   var where
   var objId = this.options.objectIdField
-  size = size > 5000 ? 5000 : size
 
   var url = this.url
   var pages = Math.max((stats.max === size) ? stats.max : Math.ceil((stats.max - stats.min) / size), 1)

--- a/index.js
+++ b/index.js
@@ -313,8 +313,9 @@ FeatureService.prototype.featureCount = function (callback) {
 /**
  * build result Offset based page requests
  * these pages use Server's built in paging via resultOffset and resultRecordCount
- * @param {number} pages - the number of pages we'll create
- * @param {number} max - the max number of feature per page
+ * @param {integer} pages - the number of pages we'll create
+ * @param {integer} size - the max number of features per page
+ * @returns {object} reqs - contains all the pages for extracting features
  */
 FeatureService.prototype._offsetPages = function (pages, size) {
   var reqs = []
@@ -337,7 +338,8 @@ FeatureService.prototype._offsetPages = function (pages, size) {
  * build `id` query based page requests
  * these pages use object ids in URLs directly
  * @param {array} ids - an array of each object id in the service
- * @param {number} maxCount - the max record count for each page
+ * @param {integer} size - the max record count for each page
+ * @returns {object} reqs - contains all the pages for extracting features
  */
 FeatureService.prototype._idPages = function (ids, size) {
   var reqs = []
@@ -363,9 +365,9 @@ FeatureService.prototype._idPages = function (ids, size) {
  * build object id query based page requests
  * these pages use object ids in where clauses via < and >
  * you could call this objectId queries
- * @param {number} min - the max object id in the service
- * @param {number} max - the max object id in the service
- * @param {number} maxCount - the max record count for each page
+ * @param {object} stats - contains the max and min object id
+ * @param {integer} size - the size of records to include in each page
+ * @returns {object} reqs - contains all the pages for extracting features
  */
 FeatureService.prototype._rangePages = function (stats, size) {
   var reqs = []

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,8 @@ test('build offset pages', function (t) {
   var pages
   var stats = {min: 0, max: 2000}
   pages = service._rangePages(stats, stats.max / 2)
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&where=OBJECTID>=0+AND+OBJECTID<=999&f=json&outFields=*&geometry=&returnGeometry=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&where=OBJECTID>=1000+AND+OBJECTID<=2000&f=json&outFields=*&geometry=&returnGeometry=true&geometryPrecision=')
   t.equal(pages.length, 2)
   pages = service._rangePages(stats, stats.max / 4)
   t.equal(pages.length, 4)
@@ -45,6 +47,7 @@ test('build result offset pages', function (t) {
   var maxCount = 100
   var pages = service._offsetPages(4, maxCount)
   t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&f=json&outFields=*&where=1=1&resultOffset=0&resultRecordCount=100&geometry=&returnGeometry=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&f=json&outFields=*&where=1=1&resultOffset=100&resultRecordCount=100&geometry=&returnGeometry=true&geometryPrecision=')
   t.equal(pages.length, 4)
 
   t.end()


### PR DESCRIPTION
This PR fixes a bug where pages generated from object id statistics always used layer index 0.
It also fixes the max record count at 5000 or less unless an option is set to increase it.
