### PR TITLE
fix errors on bad responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Don't throw exception when there is no error in the json returned from server
+* Catch non-json responses explicitly
+* Don't use zlib methods unsupported in node 0.10.* in testing
+* Error timestamps are all written in same case
+
 ## [1.2.7] - 2015-09-03
 ### Fixed
 * Correct logic for correcting against poorly instantiated FeatureServices

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ FeatureService.prototype.layerInfo = function (callback) {
     if (err || !json || json.error) {
       if (!json) json = {error: {}}
       var error = new Error('Request for layer information failed')
-      error.timeStamp = new Date()
+      error.timestamp = new Date()
       error.url = url
       error.code = json.error.code || 500
       error.body = json.error
@@ -195,7 +195,7 @@ FeatureService.prototype.layerIds = function (callback) {
     if (err || !json.objectIds) {
       if (!json) json = {error: {}}
       var error = new Error('Request for object IDs failed')
-      error.timeStamp = new Date()
+      error.timestamp = new Date()
       error.code = json.error.code || 500
       error.url = url
       error.body = err || json.error
@@ -221,7 +221,7 @@ FeatureService.prototype.featureCount = function (callback) {
       // init empty json error so we can handle building the error in one logic stream
       if (!json) json = {error: {}}
       var error = new Error('Request for feature count failed')
-      error.timeStamp = new Date()
+      error.timestamp = new Date()
       error.code = json.error.code || 500
       error.url = countUrl
       error.body = err || json.error

--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ FeatureService.prototype.statistics = function (field, stats, callback) {
   var url = this._statsUrl(field, stats)
   this.request(url, function (err, json) {
     if (err || json.error) {
+      if (!json) json = {error: {}}
       var error = new Error('Request for statistics failed')
       error.timestamp = new Date()
       error.code = json.error.code || 500
@@ -155,17 +156,12 @@ FeatureService.prototype.layerInfo = function (callback) {
      * 3. error in response json
      */
     if (err || !json || json.error) {
+      if (!json) json = {error: {}}
       var error = new Error('Request for layer information failed')
       error.timeStamp = new Date()
       error.url = url
-
-      if (json.error) {
-        error.code = json.error.code || 500
-        error.body = json.error
-      } else {
-        error.code = 500
-        error.body = err || 'missing response json'
-      }
+      error.code = json.error.code || 500
+      error.body = json.error
 
       return callback(error)
     }
@@ -198,6 +194,7 @@ FeatureService.prototype.layerIds = function (callback) {
   var url = this.url + '/' + this.layer + '/query?where=1=1&returnIdsOnly=true&f=json'
   this.request(url, function (err, json) {
     if (err || !json.objectIds) {
+      if (!json) json = {error: {}}
       var error = new Error('Request for object IDs failed')
       error.timeStamp = new Date()
       error.code = json.error.code || 500
@@ -209,6 +206,31 @@ FeatureService.prototype.layerIds = function (callback) {
     // TODO: is this really necessary
     json.objectIds.sort(function (a, b) { return a - b })
     callback(null, json.objectIds)
+  })
+}
+
+/**
+ * Count of every single feature in the service
+ * @param {object} callback - called when the service info comes back
+ */
+FeatureService.prototype.featureCount = function (callback) {
+  var countUrl = this.url + '/' + (this.layer || 0)
+  countUrl += '/query?where=1=1&returnCountOnly=true&f=json'
+
+  this.request(countUrl, function (err, json) {
+    if (err || json.error) {
+      // init empty json error so we can handle building the error in one logic stream
+      if (!json) json = {error: {}}
+      var error = new Error('Request for feature count failed')
+      error.timeStamp = new Date()
+      error.code = json.error.code || 500
+      error.url = countUrl
+      error.body = err || json.error
+
+      return callback(error)
+    }
+
+    callback(null, json)
   })
 }
 
@@ -302,29 +324,6 @@ FeatureService.prototype._getIdRangeFromStats = function (meta, callback) {
     var min = attrs.min || attrs.MIN || attrs[names[0]]
     var max = attrs.max || attrs.MAX || attrs[names[1]]
     callback(null, {min: min, max: max})
-  })
-}
-
-/**
- * Count of every single feature in the service
- * @param {object} callback - called when the service info comes back
- */
-FeatureService.prototype.featureCount = function (callback) {
-  var countUrl = this.url + '/' + (this.layer || 0)
-  countUrl += '/query?where=1=1&returnCountOnly=true&f=json'
-
-  this.request(countUrl, function (err, json) {
-    if (err || json.error) {
-      var error = new Error('Request for feature count failed')
-      error.timeStamp = new Date()
-      error.code = json.error.code || 500
-      error.url = countUrl
-      error.body = err || json.error
-
-      return callback(error)
-    }
-
-    callback(null, json)
   })
 }
 
@@ -456,10 +455,12 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
           // the error coming back here is already well formed in _decode
           if (err) return self._catchErrors(task, err, uri, cb)
           // server responds 200 with error in the payload so we have to inspect
-          if (json.error) {
+          if (!json || json.error) {
+            if (!json) json = {error: {}}
             this.error = new Error('Request for a page of features failed')
-            this.error.timeStamp = new Date()
+            this.error.timestamp = new Date()
             this.error.body = json.error
+            this.error.code = json.error.code || 500
             return self._catchErrors(task, this.error, uri, cb)
           }
           cb(null, json)
@@ -468,7 +469,6 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
     })
 
     req.setTimeout(self.timeOut, function () {
-      // kill it immediately if a timeout occurs
       this.error = new Error('The request timed out after ' + self.timeOut / 1000 + ' seconds.')
       this.error.timestamp = new Date()
       this.error.code = 504
@@ -503,18 +503,27 @@ FeatureService.prototype._decode = function (res, data, callback) {
 
   try {
     var buffer = Buffer.concat(data)
+    var response
     if (encoding === 'gzip') {
       zlib.gunzip(buffer, function (err, data) {
-        callback(err, JSON.parse(data.toString().replace(/NaN/g, 'null')))
+        response = data.toString().replace(/NaN/g, 'null')
+        callback(err, JSON.parse(response))
       })
     } else if (encoding === 'deflate') {
       zlib.inflate(buffer, function (err, data) {
-        callback(err, JSON.parse(data.toString().replace(/NaN/g, 'null')))
+        response = data.toString().replace(/NaN/g, 'null')
+        callback(err, JSON.parse(response))
       })
     } else {
-      callback(null, JSON.parse(buffer.toString().replace(/NaN/g, 'null')))
+      response = data.toString().replace(/NaN/g, 'null')
+      callback(null, JSON.parse(response))
     }
   } catch (e) {
+    // sometimes we get html or plain strings back
+    var pattern = new RegExp(/[^{\[]/)
+    if (response.slice(0, 1).match(pattern)) {
+      return callback(new Error('Received HTML or plain text when expecting JSON'))
+    }
     console.trace(e)
     callback(new Error('Failed to parse server response'))
   }

--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ FeatureService.prototype.request = function (url, callback) {
     response.on('end', function () {
       self._decode(response, data, callback)
     })
-
   })
 
   req.setTimeout(self.timeOut, function () {
@@ -314,7 +313,6 @@ FeatureService.prototype.pages = function (callback) {
  * @param {function} callback - returns with an error or objectID stats
  */
 FeatureService.prototype._getIdRangeFromStats = function (meta, callback) {
-
   this.statistics(meta.oid, ['min', 'max'], function (err, stats) {
     // TODO this is handled elsewhere now so move it
     if (err) return callback(err)

--- a/test/index.js
+++ b/test/index.js
@@ -218,7 +218,7 @@ test('time out when there is no response', function (t) {
 test('decoding something that is gzipped', function (t) {
   var json = JSON.stringify(JSON.parse(fs.readFileSync('./test/fixtures/uncompressed.json')))
   zlib.gzip(json, function (err, gzipped) {
-    if (err) t.end()
+    t.error(err)
     var data = [gzipped]
     var res = {headers: {'content-encoding': 'gzip'}}
     var service = new FeatureService('http://service.com/mapserver/2')
@@ -234,7 +234,7 @@ test('decoding something that is gzipped', function (t) {
 test('decoding something that is deflated', function (t) {
   var json = JSON.stringify(JSON.parse((fs.readFileSync('./test/fixtures/uncompressed.json'))))
   zlib.deflate(json, function (err, deflated) {
-    if (err) t.end()
+    t.error(err)
     var data = [deflated]
     var res = {headers: {'content-encoding': 'deflate'}}
 
@@ -252,6 +252,7 @@ test('decoding something that is not compressed', function (t) {
   var res = {headers: {}}
 
   service._decode(res, data, function (err, json) {
+    t.error(err)
     t.equal(json.features.length, 2000)
     t.end()
   })
@@ -417,7 +418,6 @@ test('building pages for a version 10.0 server', function (t) {
     t.equal(pages.length, 1)
     t.end()
   })
-
 })
 
 test('service times out on third try for features', function (t) {


### PR DESCRIPTION
This PR cleans up a bunch of cases where an exception would be thrown when no json is returned on a error from ArcGIS server or there is no error object in the json.

There are a few other minor fixes listed in the changelog.

ping @koopjs/dev 
