### PR TITLE
add option for passed in logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+* Allow a logger to be passed in through options.logger when initializing a new service 
+
 ### Fixed
 * Don't throw exception when there is no error in the json returned from server
 * Catch non-json responses explicitly

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ var url = 'http://....../FeatureServer/0'
 var service = new FeatureService(url, options)
 ```
 
+### Options
+An object passed as the second parameter when initializing a service
+- layer: the layer index to use
+- size: the maximum page size when requesting features
+- concurrency: the maximum concurrency for requesting features from a single server
+- timeOut: the amount of time to wait with no response before cancelling a request
+- logger: An object with a log method that takes a level and a message e.g. a Winston instance
+
 ### API
 
 #### layerIds(callback)

--- a/test/index.js
+++ b/test/index.js
@@ -325,6 +325,7 @@ test('requesting a page of features', function (t) {
   var task = {req: 'http://servicesqa.arcgis.com/97KLIFOSt5CxbiRI/arcgis/rest/services/QA_data_simple_point_5000/FeatureServer/0/query?outSR=4326&f=json&outFields=*&where=1=1&resultOffset=1000&resultRecordCount=1000&geometry=&returnGeometry=true&geometryPrecision='}
 
   service._requestFeatures(task, function (err, json) {
+    t.error(err)
     t.equal(json.features.length, 1000)
     t.end()
   })
@@ -399,7 +400,6 @@ test('building pages from a layer where statistics fail', function (t) {
     t.equal(pages.length, 4)
     t.end()
   })
-
 })
 
 test('building pages for a version 10.0 server', function (t) {
@@ -421,8 +421,7 @@ test('building pages for a version 10.0 server', function (t) {
 })
 
 test('service times out on third try for features', function (t) {
-  var service = new FeatureService('http://www.foobar.com')
-  service.timeOut = 5
+  var service = new FeatureService('http://www.foobar.com', {timeOut: 5})
   nock('http://www.foobar.com').get('/').socketDelay(100).reply({}.toString())
   sinon.stub(service, '_abortPaging', function (err, callback) {
     callback(err)
@@ -462,6 +461,27 @@ test('catching errors with a json payload', function (t) {
     service._abortPaging.restore()
     t.end()
   })
+})
 
+test('logging with a passed in logger', function (t) {
+  var logger = {}
+  logger.log = function (level, message) {
+    t.equal(level, 'test')
+    t.equal(message, 'test')
+    t.end()
+  }
+  var service = new FeatureService('htt://service.com/mapserver/3', {logger: logger})
+  service.log('test', 'test')
+})
+
+test('logging without a passed in logger', function (t) {
+  sinon.stub(service, '_console', function (level, message) {
+    t.equal(level, 'test')
+    t.equal(message, 'test')
+    service._console.restore()
+    t.end()
+  })
+
+  service.log('test', 'test')
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -465,6 +465,7 @@ test('catching errors with a json payload', function (t) {
 
 test('logging with a passed in logger', function (t) {
   var logger = {}
+  t.plan(2)
   logger.log = function (level, message) {
     t.equal(level, 'test')
     t.equal(message, 'test')
@@ -475,6 +476,7 @@ test('logging with a passed in logger', function (t) {
 })
 
 test('logging without a passed in logger', function (t) {
+  t.plan(2)
   sinon.stub(service, '_console', function (level, message) {
     t.equal(level, 'test')
     t.equal(message, 'test')

--- a/test/index.js
+++ b/test/index.js
@@ -469,7 +469,6 @@ test('logging with a passed in logger', function (t) {
   logger.log = function (level, message) {
     t.equal(level, 'test')
     t.equal(message, 'test')
-    t.end()
   }
   var service = new FeatureService('htt://service.com/mapserver/3', {logger: logger})
   service.log('test', 'test')
@@ -481,7 +480,6 @@ test('logging without a passed in logger', function (t) {
     t.equal(level, 'test')
     t.equal(message, 'test')
     service._console.restore()
-    t.end()
   })
 
   service.log('test', 'test')


### PR DESCRIPTION
This PR allows a custom logger object to be passed in a when a service is initializied through options.logger. If no logger is passed in, it will default to console logging. It was built with https://github.com/winstonjs/winston in mind, but it should work with any object that has a log method that takes a level and message as arguments.

cc @koopjs/dev 
