### PR TITLE
fix bug with uncompressed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Return the page that was sucessfully completed when getting features
+
+### Fixed
+* No longer failing to parse multi-chunk feature service responses that are not compressed
+
 ## [1.3.1]
 ### Fixed
 * Log retry urls correclty

--- a/index.js
+++ b/index.js
@@ -548,7 +548,7 @@ FeatureService.prototype._decode = function (res, data, callback) {
         callback(err, JSON.parse(response))
       })
     } else {
-      response = data.toString().replace(/NaN/g, 'null')
+      response = buffer.toString().replace(/NaN/g, 'null')
       callback(null, JSON.parse(response))
     }
   } catch (e) {

--- a/test/index.js
+++ b/test/index.js
@@ -248,7 +248,10 @@ test('decoding something that is deflated', function (t) {
 
 test('decoding something that is not compressed', function (t) {
   var uncompressed = JSON.stringify(JSON.parse(fs.readFileSync('./test/fixtures/uncompressed.json')))
-  var data = [new Buffer(uncompressed)]
+  var buffer = new Buffer(uncompressed)
+  var buf1 = buffer.slice(0, -1)
+  var buf2 = buffer.slice(-1)
+  var data = [buf1, buf2]
   var res = {headers: {}}
 
   service._decode(res, data, function (err, json) {


### PR DESCRIPTION
This fixes a bug where we did not concatenate the buffer on uncompressed http responses. This led to JSON parsing failures.
