### PR TITLE
[DNM] be defensive with external callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Be defensive when triggering a passed-in callback
+
 ## [1.4.2] - 2015-10-13
 ### Changed
 * Removed callback from parse try statement
@@ -12,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.4.0] - 2015-10-12
 ### Added
-* Backoff time for failed requests can now be set as an option 
+* Backoff time for failed requests can now be set as an option
 * `service.info` returns information about the feature or map service
 
 ### Changed
@@ -28,7 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.0]
 ### Added
-* Allow a logger to be passed in through options.logger when initializing a new service 
+* Allow a logger to be passed in through options.logger when initializing a new service
 
 ### Fixed
 * Don't throw exception when there is no error in the json returned from server
@@ -40,7 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Correct logic for correcting against poorly instantiated FeatureServices
 
-## [1.2.6] - 2015-09-02 
+## [1.2.6] - 2015-09-02
 ### Fixed
 * Don't set a layer id with a query string
 * Don't set a url with a query string
@@ -173,4 +177,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.0.3]: https://github.com/koopjs/featureservice/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/koopjs/featureservice/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/koopjs/featureservice/releases/tag/v0.0.1
-

--- a/index.js
+++ b/index.js
@@ -526,7 +526,14 @@ FeatureService.prototype._requestFeatures = function (task, cb) {
             this.error.code = json.error.code || 500
             return self._catchErrors(task, this.error, uri, cb)
           }
-          cb(null, json, task)
+          // since we are potentially running with concurrency > 1 in upstream applications
+          // there is a chance that this passed in callback may be triggered multiple times
+          // therefor we need to be defensive here and log an error
+          try {
+            cb(null, json, task)
+          } catch (e) {
+            self.log('error', e)
+          }
         })
       })
     })


### PR DESCRIPTION
This PR fixes an issue where a callback passed in from an upstream application may be triggered multiple times. We use a try/catch instead of throwing an exception.
