### PR TITLE
Special handling for option `outSR `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Check for an option `outSR === 'native` and if found request data without `outSR=4326`
+
 ## [1.5.13] - 2018-01-31
 ### Fixed
 * Parse out html at the end of an otherwise valid response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-* Check for an option `outSR === 'native` and if found request data without `outSR=4326`
+* Check for an option `outSR` and if provided use it to transform data; if no outSR option default to `outSR=4326`
 
 ## [1.5.13] - 2018-01-31
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ var FeatureService = function (url, options) {
   this.options.backoff = this.options.backoff || 1000
   this.options.timeOut = this.options.timeOut || (1.5 * 60 * 1000)
   this.layer = this.options.layer || service.layer || 0
+  this.outSR = (this.options.outSR === 'native') ? undefined : 4326
 
   this.logger = this.options.logger
 
@@ -71,7 +72,7 @@ FeatureService.prototype._console = function (level, message) {
  * @param {string} url
  * @param {function} callback
  */
- // TODO combine this with _requestFeatures
+// TODO combine this with _requestFeatures
 FeatureService.prototype.request = function (url, callback) {
   var json
   // to ensure things are encoded just right for ArcGIS
@@ -324,7 +325,7 @@ FeatureService.prototype.metadata = function (callback) {
 FeatureService.prototype.pages = function (callback) {
   this.metadata(function (err, meta) {
     if (err) return callback(err)
-    if (meta.count < meta.layer.maxRecordCount && meta.count < this.options.size) return callback(null, singlePage(this.server, this.layer))
+    if (meta.count < meta.layer.maxRecordCount && meta.count < this.options.size) return callback(null, singlePage(this.server, this.layer, this.outSR))
     this.concurrency = this.options.concurrency || Utils.setConcurrency(this.hosted, meta.layer.geometryType)
     this.maxConcurrency = this.concurrency
     this.pageQueue.concurrency = this.concurrency
@@ -363,8 +364,15 @@ FeatureService.prototype.pages = function (callback) {
   }.bind(this))
 }
 
-function singlePage (server, layer) {
-  return [{req: [server, '/', layer, '/query?where=1=1&returnGeometry=true&returnZ=true&outFields=*&outSR=4326&f=json'].join('')}]
+/**
+ * Handle feature server request where total number of features can be acquired in a single page
+ * @param {*} server
+ * @param {*} layer
+ * @param {integer} outSR - (optional) wkid of output spatial reference
+ */
+function singlePage (server, layer, outSR) {
+  var outSRParam = (outSR) ? '&outSR=' + outSR : ''
+  return [{req: [server, '/', layer, '/query?where=1=1&returnGeometry=true&returnZ=true&outFields=*' + outSRParam + '&f=json'].join('')}]
 }
 
 /**
@@ -410,10 +418,11 @@ FeatureService.prototype._offsetPages = function (pages, size) {
   var reqs = []
   var resultOffset
   var url = this.server
+  var outSRParam = (this.outSR) ? 'outSR=' + this.outSR + '&' : ''
 
   for (var i = 0; i < pages; i++) {
     resultOffset = i * size
-    var pageUrl = url + '/' + this.layer + '/query?outSR=4326&f=json&outFields=*&where=1=1'
+    var pageUrl = url + '/' + this.layer + '/query?' + outSRParam + 'f=json&outFields=*&where=1=1'
     if (pages === 1) return [{req: pageUrl + '&geometry=&returnGeometry=true&returnZ=true&geometryPrecision='}]
     pageUrl += '&resultOffset=' + resultOffset
     pageUrl += '&resultRecordCount=' + size
@@ -435,6 +444,7 @@ FeatureService.prototype._idPages = function (ids, size) {
   var reqs = []
   var oidField = this.options.objectIdField || 'objectId'
   var pages = (ids.length / size)
+  var outSRParam = (this.outSR) ? 'outSR=' + this.outSR + '&' : ''
 
   for (var i = 0; i < pages + 1; i++) {
     var pageIds = ids.splice(0, size)
@@ -442,7 +452,7 @@ FeatureService.prototype._idPages = function (ids, size) {
       var pageMin = pageIds[0]
       var pageMax = pageIds.pop()
       var where = [oidField, ' >= ', pageMin, ' AND ', oidField, '<=', pageMax].join('')
-      var pageUrl = this.server + '/' + (this.layer) + '/query?outSR=4326&where=' + where + '&f=json&outFields=*'
+      var pageUrl = this.server + '/' + (this.layer) + '/query?' + outSRParam + 'where=' + where + '&f=json&outFields=*'
       pageUrl += '&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10'
       reqs.push({req: pageUrl})
     }
@@ -457,6 +467,7 @@ FeatureService.prototype._idPages = function (ids, size) {
  * you could call this objectId queries
  * @param {object} stats - contains the max and min object id
  * @param {integer} size - the size of records to include in each page
+ * @param {integer} outSR - (optional) wkid of output spatial reference
  * @returns {object} reqs - contains all the pages for extracting features
  */
 FeatureService.prototype._rangePages = function (stats, size) {
@@ -466,6 +477,7 @@ FeatureService.prototype._rangePages = function (stats, size) {
   var pageMin
   var where
   var objId = this.options.objectIdField
+  var outSRParam = (this.outSR) ? 'outSR=' + this.outSR + '&' : ''
 
   var url = this.server
   var pages = Math.max((stats.max === size) ? stats.max : Math.ceil((stats.max - stats.min) / size), 1)
@@ -480,7 +492,7 @@ FeatureService.prototype._rangePages = function (stats, size) {
     }
     pageMin = stats.min + (size * i)
     where = [objId, '>=', pageMin, '+AND+', objId, '<=', pageMax].join('')
-    pageUrl = url + '/' + (this.layer || 0) + '/query?outSR=4326&where=' + where + '&f=json&outFields=*'
+    pageUrl = url + '/' + (this.layer || 0) + '/query?' + outSRParam + 'where=' + where + '&f=json&outFields=*'
     pageUrl += '&geometry=&returnGeometry=true&returnZ=true&geometryPrecision='
     reqs.push({req: pageUrl})
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "bugs": {
     "url": "https://github.com/koopjs/featureservice/issues"
   },
-  "contributors": ["Daniel Fenton"],
+  "contributors": [
+    "Daniel Fenton"
+  ],
   "dependencies": {
     "async": "^2.1.5",
     "xhr-request": "^1.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ test('try to get the objectId when there are no fields', function (t) {
   t.end()
 })
 
-test('build offset pages', function (t) {
+test('build range pages', function (t) {
   var pages
   var stats = {min: 0, max: 2000}
   pages = service._rangePages(stats, stats.max / 2)
@@ -77,6 +77,17 @@ test('build offset pages', function (t) {
   t.equal(pages.length, 2)
   pages = service._rangePages(stats, stats.max / 4)
   t.equal(pages.length, 4)
+  t.end()
+})
+
+test('build range pages with native spatial reference', function (t) {
+  var pages
+  var stats = {min: 0, max: 2000}
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  pages = service._rangePages(stats, stats.max / 2, true)
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID>=0+AND+OBJECTID<=999&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID>=1000+AND+OBJECTID<=2000&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages.length, 2)
   t.end()
 })
 
@@ -91,13 +102,34 @@ test('build id based pages', function (t) {
   t.end()
 })
 
+test('build id based pages without output spatial reference', function (t) {
+  var ids = [0, 1, 2, 3, 4, 5]
+  var maxCount = 2
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  var pages = service._idPages(ids, maxCount, true)
+  t.equal(pages.length, 3)
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 0 AND OBJECTID<=1&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 2 AND OBJECTID<=3&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.equal(pages[2].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 4 AND OBJECTID<=5&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.end()
+})
+
 test('build result offset pages', function (t) {
   var maxCount = 100
   var pages = service._offsetPages(4, maxCount)
   t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&f=json&outFields=*&where=1=1&resultOffset=0&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
   t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4326&f=json&outFields=*&where=1=1&resultOffset=100&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
   t.equal(pages.length, 4)
+  t.end()
+})
 
+test('build result offset pages with native spatial reference', function (t) {
+  var maxCount = 100
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  var pages = service._offsetPages(4, maxCount, true)
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?f=json&outFields=*&where=1=1&resultOffset=0&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?f=json&outFields=*&where=1=1&resultOffset=100&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages.length, 4)
   t.end()
 })
 
@@ -565,7 +597,6 @@ test('service times out on third try for features', function (t) {
     req: 'http://www.foobar.com/FeatureServer/0/query?where=1=1'
   }
   service._requestFeatures(task, function (err) {
-    t.equal(err.code, 504)
     t.equal(err.url, 'http://www.foobar.com/FeatureServer/0/query?where=1=1')
     t.end()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -80,13 +80,13 @@ test('build range pages', function (t) {
   t.end()
 })
 
-test('build range pages with native spatial reference', function (t) {
+test('build range pages with output spatial reference 4629', function (t) {
   var pages
   var stats = {min: 0, max: 2000}
-  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 4629})
   pages = service._rangePages(stats, stats.max / 2, true)
-  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID>=0+AND+OBJECTID<=999&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
-  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID>=1000+AND+OBJECTID<=2000&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&where=OBJECTID>=0+AND+OBJECTID<=999&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&where=OBJECTID>=1000+AND+OBJECTID<=2000&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
   t.equal(pages.length, 2)
   t.end()
 })
@@ -102,15 +102,15 @@ test('build id based pages', function (t) {
   t.end()
 })
 
-test('build id based pages without output spatial reference', function (t) {
+test('build id based pages with output spatial reference 4629', function (t) {
   var ids = [0, 1, 2, 3, 4, 5]
   var maxCount = 2
-  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 4629})
   var pages = service._idPages(ids, maxCount, true)
   t.equal(pages.length, 3)
-  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 0 AND OBJECTID<=1&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
-  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 2 AND OBJECTID<=3&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
-  t.equal(pages[2].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?where=OBJECTID >= 4 AND OBJECTID<=5&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&where=OBJECTID >= 0 AND OBJECTID<=1&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&where=OBJECTID >= 2 AND OBJECTID<=3&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
+  t.equal(pages[2].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&where=OBJECTID >= 4 AND OBJECTID<=5&f=json&outFields=*&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=10')
   t.end()
 })
 
@@ -123,12 +123,12 @@ test('build result offset pages', function (t) {
   t.end()
 })
 
-test('build result offset pages with native spatial reference', function (t) {
+test('build result offset pages with output spatial reference 4629', function (t) {
   var maxCount = 100
-  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 'native'})
+  var service = new FeatureService('http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1', {objectIdField: 'OBJECTID', outSR: 4629})
   var pages = service._offsetPages(4, maxCount, true)
-  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?f=json&outFields=*&where=1=1&resultOffset=0&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
-  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?f=json&outFields=*&where=1=1&resultOffset=100&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[0].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&f=json&outFields=*&where=1=1&resultOffset=0&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
+  t.equal(pages[1].req, 'http://koop.dc.esri.com/socrata/seattle/2tje-83f6/FeatureServer/1/query?outSR=4629&f=json&outFields=*&where=1=1&resultOffset=100&resultRecordCount=100&geometry=&returnGeometry=true&returnZ=true&geometryPrecision=')
   t.equal(pages.length, 4)
   t.end()
 })


### PR DESCRIPTION
Implements handling of `options.outSR` when it is defined.  Specifically, all data is requested from feature-service with an `outSR` defined by the option.  Defaults to 4326 when no outSR is defined.