### PR TITLE
throw error on non-map/featureserver + test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.2] - 2019-11-05
+### Changed
+* Throw `TypeError` when URL is not a FeatureServer or MapServer with optional layer
+
 ## [1.6.1] - 2018-11-28
 ### Changed
 * Double check pagination support with a request for the second page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.6.2] - 2019-11-05
-### Changed
+### Unreleased 
 * Throw `TypeError` when URL is not a FeatureServer or MapServer with optional layer
 
 ## [1.6.1] - 2018-11-28

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,10 +18,16 @@ module.exports = {
    * @return {object} contains the layer, the server and whether or not the server is hosted
    */
   parseUrl: function (url) {
-    var layer = url.match(/(?:.+\/(?:feature|map)server\/)(\d+)/i)
+    // @todo: use the URL class once pre-node 6 has been deprecated
+    var match = url.match(/^(.+?\/(?:feature|map)server)(?:\/(\d+))?/i)
+
+    if (null === match) {
+      throw new TypeError('unable to parse ' + url + ' as a mapserver or featureserver with optional layer')
+    }
+
     return {
-      layer: layer && layer[1] ? layer[1] : undefined,
-      server: url.match(/.+\/(feature|map)server/i)[0],
+      layer: match[2],
+      server: match[1],
       hosted: /services(\d)?(qa|dev)?.arcgis.com/.test(url)
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "featureservice",
   "description": "Get all features from an Esri Feature Service",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "Chris Helm",
   "bugs": {
     "url": "https://github.com/koopjs/featureservice/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "featureservice",
   "description": "Get all features from an Esri Feature Service",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "author": "Chris Helm",
   "bugs": {
     "url": "https://github.com/koopjs/featureservice/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -513,6 +513,7 @@ test('building pages for a service that supports pagination', function (t) {
   .reply(200, features)
 
   var service = new FeatureService('http://services3.arcgis.com/Infrastructure/Railroads_Rail_Crossings_INDOT/MapServer/0', {})
+
   service.pages(function (err, pages) {
     t.equal(err, null)
     t.equal(pages.length, 156)
@@ -702,4 +703,15 @@ test('setting concurrency for an on-premise point service', function (t) {
   t.plan(1)
   var concurrency = Utils.setConcurrency(false, 'esriGeometryPoint')
   t.equal(concurrency, 4)
+})
+
+test('url not parseable as mapserver or featureserver with layer should throw error', function (t) {
+  try {
+    Utils.parseUrl('http://example.com/')
+    t.fail('an error should have been thrown')
+  } catch (err) {
+    t.ok(err instanceof TypeError)
+    t.equals(err.message, 'unable to parse http://example.com/ as a mapserver or featureserver with optional layer')
+  }
+  t.end()
 })


### PR DESCRIPTION
This PR updates the following:

- combines the 2 regexps into 1 for performance
- throws an error if unparseable as a FeatureServer or MapServer w/optional layer
- adds a test

Without this change, the parser throws a rather unhelpful `Cannot read property '0' of null` error when URL is not a MapServer/FeatureServer.  